### PR TITLE
fix(azspeedtest.psm1): change case of Public / Private

### DIFF
--- a/AzSpeedTest/AzSpeedTest.psm1
+++ b/AzSpeedTest/AzSpeedTest.psm1
@@ -1,12 +1,12 @@
 
 #Set-StrictMode -Version 2.0
 
-$script:storageLocations = Get-Content -Path (Join-Path -Path $PSScriptRoot -ChildPath 'private/storageLocations.json') -Raw |
+$script:storageLocations = Get-Content -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Private/storageLocations.json') -Raw |
     ConvertFrom-Json
 
 # Dot source public/private functions
-$public =  @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'public/*.ps1') -Recurse -ErrorAction Stop)
-$private = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'private/*.ps1') -Recurse -ErrorAction Stop)
+$public =  @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Public/*.ps1') -Recurse -ErrorAction Stop)
+$private = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Private/*.ps1') -Recurse -ErrorAction Stop)
 foreach ($import in @($public + $private)) {
     try {
         . $import.FullName


### PR DESCRIPTION
this makes the code work correctly on *nix platforms, as the folders are created capitalised, so
will not import natively

This will fix the issue mentioned at https://www.reddit.com/r/PowerShell/comments/8dljp9/azure_speed_test_tool_for_powershell/dxogi24

The folders are named `Public` and `Private` in the repo, but referred to as `public` and `private` in the module. I have changed these to match, which will allow macOS and Linux to use the module correctly, as well as keeping Windows compatibility as this is not a Case Sensitive OS